### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ It is pretty simple. And just triggers a bunch of events:
         app publish                      emited when app-node sends command to publish something (send, broadcast)
         app subscribe-to-channel         emited when app-node sends command to subscribe some client to some channel
         app unsubscribe-from-channel     emited when app-node sends command to unsubscribe some client from some channel
-    socket connection                    emited when some client is conected to SocketIO
+    socket connection                    emited when some client is connected to SocketIO
     socket message                       emited when some client sends message
     socket disconnect                    emited when some client is disconnected
 


### PR DESCRIPTION
@muchmala, I've corrected a typographical error in the documentation of the [socket.io-cluster](https://github.com/muchmala/socket.io-cluster) project. Specifically, I've changed conected to connected. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
